### PR TITLE
Fix genre-book relationship

### DIFF
--- a/SmartCommerceX/SmartCommerceX/Data/ApplicationDbContext.cs
+++ b/SmartCommerceX/SmartCommerceX/Data/ApplicationDbContext.cs
@@ -85,7 +85,7 @@ namespace SmartCommerceX.Data
             // Book - Genre: many-to-one
             builder.Entity<Book>()
                 .HasOne(b => b.Genre)
-                .WithMany(g => g.Products)
+                .WithMany(g => g.Books)
                 .HasForeignKey(b => b.GenreId)
                 .OnDelete(DeleteBehavior.Restrict);
 

--- a/SmartCommerceX/SmartCommerceX/Models/Genre.cs
+++ b/SmartCommerceX/SmartCommerceX/Models/Genre.cs
@@ -7,6 +7,6 @@ namespace SmartCommerceX.Models
         public string Name { get; set; }
         public string? Description { get; set; }
 
-        public ICollection<Product> Products { get; set; }
+        public ICollection<Book> Books { get; set; } = new List<Book>();
     }
 } 


### PR DESCRIPTION
## Summary
- fix `Genre` navigation property in SmartCommerceX
- update `OnModelCreating` to reference `Genre.Books`

## Testing
- `dotnet build SmartCommerceX/SmartCommerceX/SmartCommerceX.csproj -nologo` *(fails: current .NET SDK does not support net9.0)*
- `dotnet build SmartCommerce/SmartCommerce.csproj -nologo` *(fails: current .NET SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6883a8e3a56483269c048d648b8f32a4